### PR TITLE
Use transformers-compat

### DIFF
--- a/smtp-mail-ng.cabal
+++ b/smtp-mail-ng.cabal
@@ -72,7 +72,7 @@ library
                , transformers-compat >= 0.3
                , bytestring >=0.10 && <0.11
                , haskeline >=0.7 && <0.8
-               , mtl >=2.2 && <2.3
+               , mtl >=2.0 && <2.3
                , attoparsec >=0.12 && <0.13
                , filepath >=1.3 && <1.4
                , text >=1.2 && <1.3

--- a/smtp-mail-ng.cabal
+++ b/smtp-mail-ng.cabal
@@ -10,7 +10,7 @@ name:                smtp-mail-ng
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.1.0.0
+version:             0.1.0.1
 
 -- A short (one-line) description of the package.
 synopsis:            An SMTP client EDSL
@@ -68,7 +68,8 @@ library
   build-depends: base >=4.7 && <4.8
                , network >=2.6 && <2.7
                , mime-mail >=0.4 && <0.5
-               , transformers >=0.4 && <0.5
+               , transformers >= 0.2
+               , transformers-compat >= 0.3
                , bytestring >=0.10 && <0.11
                , haskeline >=0.7 && <0.8
                , mtl >=2.2 && <2.3


### PR DESCRIPTION
@peti points out that depending on transformers >= 0.4 is no good for GHC 7.8.4 users. This change lowers that to >= 0.2 and brings in transformers-compat for the ExceptT transformer.
