### PR TITLE
fix compilation with latest TLS >= 1.3 and remove deprecated crypto packages

### DIFF
--- a/Network/Mail/SMTP/Auth.hs
+++ b/Network/Mail/SMTP/Auth.hs
@@ -7,8 +7,9 @@ module Network.Mail.SMTP.Auth (
 
   ) where
 
-import Crypto.Hash.MD5 (hash)
-import qualified Data.ByteString.Base16 as B16  (encode)
+import Crypto.Hash (MD5)
+import Crypto.MAC.HMAC (hmac, HMAC)
+import Data.ByteArray.Encoding (convertToBase, Base(Base16))
 import qualified Data.ByteString.Base64 as B64  (encode)
 
 import Data.ByteString  (ByteString)
@@ -44,16 +45,6 @@ toAscii = B.pack . map (toEnum.fromEnum)
 b64Encode :: String -> ByteString
 b64Encode = B64.encode . toAscii
 
-hmacMD5 :: ByteString -> ByteString -> ByteString
-hmacMD5 text key = hash (okey <> hash (ikey <> text))
-    where key' = if B.length key > 64
-                 then hash key <> B.replicate 48 0
-                 else key <> B.replicate (64-B.length key) 0
-          ipad = B.replicate 64 0x36
-          opad = B.replicate 64 0x5c
-          ikey = B.pack $ B.zipWith xor key' ipad
-          okey = B.pack $ B.zipWith xor key' opad
-
 encodePlain :: UserName -> Password -> ByteString
 encodePlain user pass = b64Encode $ intercalate "\0" [user, user, pass]
 
@@ -62,7 +53,7 @@ encodeLogin user pass = (b64Encode user, b64Encode pass)
 
 cramMD5 :: String -> UserName -> Password -> ByteString
 cramMD5 challenge user pass =
-    B64.encode $ B8.unwords [user', B16.encode (hmacMD5 challenge' pass')]
+    B64.encode $ B8.unwords [user', convertToBase Base16 (hmac challenge' pass' :: HMAC MD5)]
   where
     challenge' = toAscii challenge
     user'      = toAscii user

--- a/Network/Mail/SMTP/SMTP.hs
+++ b/Network/Mail/SMTP/SMTP.hs
@@ -191,14 +191,12 @@ tlsUpgrade context = SMTP $ do
 --   coerce it into a first-class value.
 makeTLSContext :: Handle -> HostName -> IO Context
 makeTLSContext handle hostname = do
-  -- Grab a random number generator.
-  rng <- (createEntropyPool >>= return . cprgCreate) :: IO SystemRNG
   -- Find the certificate store. No error reporting if we can't find it; you'll
   -- just (probably) get an error later when the TLS handshake fails due to
   -- an unknown CA.
   certStore <- getSystemCertificateStore
   let params = tlsClientParams hostname certStore
-  contextNew handle params rng
+  contextNew handle params
 
 -- | ClientParams are a slight variation on the default: we throw in a given
 --   certificate store and widen the supported ciphers.

--- a/smtp-mail-ng.cabal
+++ b/smtp-mail-ng.cabal
@@ -76,13 +76,12 @@ library
                , attoparsec >=0.12 && <0.14
                , filepath >=1.3 && <1.5
                , text >=1.2 && <1.3
-               , cryptohash >=0.11 && <0.12
-               , base16-bytestring >=0.1 && <0.2
+               , cryptonite
+               , memory
                , base64-bytestring >=1.0 && <1.1
-               , tls >=1.2 && <1.4
+               , tls >=1.3 && <1.4
                , x509-system >=1.5 && <1.7
                , x509-store >=1.5 && <1.7
-               , crypto-random >=0.0 && <0.1
                , stringsearch >= 0.3.6.5
   
   -- Directories containing source files.


### PR DESCRIPTION
- remove deprecated `cryptohash` and `cryptorandom` in favor of `cryptonite`
- remove `base16-bytestring` in favor of `memory` that can convert more elaborate type like (HMAC)
- adapt to work with `tls` 1.3 (removal of the rng parameter)
